### PR TITLE
Remove trailing "|" when phone number is missing

### DIFF
--- a/templates/Berlin.tsx
+++ b/templates/Berlin.tsx
@@ -101,6 +101,18 @@ function Berlin(props: TemplateProps) {
     );
   }
 
+  function renderEmail() {
+    if (or(isEmpty(about.email), hideSensitiveData)) {
+      return null;
+    }
+
+    if (isEmpty(about.phone)) {
+      return about.email;
+    }
+
+    return `${about.email} | `;
+  }
+
   function renderSummary(summary: string) {
     if (isEmpty(summary)) {
       return null;
@@ -177,9 +189,7 @@ function Berlin(props: TemplateProps) {
           <Text mb={10} color="#717171">
             {renderLocation()}
             {renderWebsite()}
-            {or(isEmpty(about.email), hideSensitiveData)
-              ? null
-              : `${about.email} | `}
+            {renderEmail()}
             {hideSensitiveData ? null : about.phone}
           </Text>
           {renderSummary(about.summary)}


### PR DESCRIPTION
Hey, thanks for sharing this project! 

I was testing it out and did _not_ want to include my phone number, but I noticed that I couldn't get rid of the trailing "|" at the end of the line (on Berlin template). Example image below 👇

<img width="293" alt="no-phone" src="https://user-images.githubusercontent.com/5217136/219883106-31bf8ea9-fa2e-4dab-8b3e-74bcd8a4a453.png">

I replaced the inline conditionals with a `renderEmail` method to fix this issue. Let me know if you have any questions.